### PR TITLE
Notification improvements

### DIFF
--- a/QuickLyric/src/main/AndroidManifest.xml
+++ b/QuickLyric/src/main/AndroidManifest.xml
@@ -135,6 +135,11 @@
                 <action android:name="com.nullsoft.winamp.metachanged" />
             </intent-filter>
         </receiver>
+
+        <service
+            android:name=".service.NotificationService"
+            android:exported="true" >
+        </service>
     </application>
 
 </manifest>

--- a/QuickLyric/src/main/AndroidManifest.xml
+++ b/QuickLyric/src/main/AndroidManifest.xml
@@ -114,6 +114,7 @@
                 <action android:name="com.jrtstudio.music.metachanged" />
                 <action android:name="com.jrtstudio.AnotherMusicPlayer.metachanged" />
                 <action android:name="com.android.music.metachanged" />
+                <action android:name="com.android.music.playstatechanged" />
                 <action android:name="com.htc.music.metachanged" />
                 <action android:name="com.rdio.android.playstatechanged" />
                 <action android:name="fm.last.android.metachanged" />

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/Keys.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/Keys.java
@@ -17,5 +17,5 @@ package com.geecko.QuickLyric;
  * along with QuickLyric.  If not, see <http://www.gnu.org/licenses/>.
  */
 public class Keys {
-    public static final String lastFM = "8165c668a50fee44f7bbd184a7cd7743";
+    public static final String lastFM = "402bdca12feff2668e36a9aa3c675273";
 }

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/Keys.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/Keys.java
@@ -17,5 +17,5 @@ package com.geecko.QuickLyric;
  * along with QuickLyric.  If not, see <http://www.gnu.org/licenses/>.
  */
 public class Keys {
-    public static final String lastFM = "402bdca12feff2668e36a9aa3c675273";
+    public static final String lastFM = "8165c668a50fee44f7bbd184a7cd7743";
 }

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -26,6 +26,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
@@ -118,7 +119,10 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
                 notifBuilder.setContentTitle(context.getString(R.string.app_name));
                 notifBuilder.setContentText(String.format("%s - %s", artist, track));
                 notifBuilder.setContentIntent(pendingIntent);
-                notifBuilder.setPriority(-1);
+                if (sharedPref.getBoolean("pref_hide_notification", false) && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN))
+                    notifBuilder.setPriority(Notification.PRIORITY_MIN);
+                else
+                    notifBuilder.setPriority(-1);
                 Notification notif = notifBuilder.build();
                 if (notificationPref == 2)
                     notif.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -70,10 +70,6 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
         String track = extras.getString("track");
         boolean isPlaying = extras.getBoolean("playing");
 
-        System.out.println(artist);
-        System.out.println(track);
-        System.out.println(isPlaying);
-
         if (intent.getAction().equals("com.amazon.mp3.metachanged")) {
             artist = extras.getString("com.amazon.mp3.artist");
             track = extras.getString("com.amazon.mp3.track");

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -68,6 +68,11 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
 
         String artist = extras.getString("artist");
         String track = extras.getString("track");
+        boolean isPlaying = extras.getBoolean("playing");
+
+        System.out.println(artist);
+        System.out.println(track);
+        System.out.println(isPlaying);
 
         if (intent.getAction().equals("com.amazon.mp3.metachanged")) {
             artist = extras.getString("com.amazon.mp3.artist");
@@ -81,14 +86,15 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
 
         SharedPreferences current = context.getSharedPreferences("current_music", Context.MODE_PRIVATE);
 
-        String currentArtist = current.getString("artist", "Michael Jackson");
-        String currentTrack = current.getString("track", "Bad");
+//        String currentArtist = current.getString("artist", "Michael Jackson");
+//        String currentTrack = current.getString("track", "Bad");
 
-        if (!currentArtist.equals(artist) || !currentTrack.equals(track)) {
+//        if (!currentArtist.equals(artist) || !currentTrack.equals(track)) {
 
             SharedPreferences.Editor editor = current.edit();
             editor.putString("artist", artist);
             editor.putString("track", track);
+            editor.putBoolean("playing", isPlaying);
             editor.apply();
 
             mAutoUpdate = mAutoUpdate || sharedPref.getBoolean("pref_auto_refresh", false);
@@ -104,11 +110,13 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
             Intent serviceIntent = new Intent(context, NotificationService.class);
             serviceIntent.putExtra("artist", artist);
             serviceIntent.putExtra("track", track);
+            serviceIntent.putExtra("playing", isPlaying);
             if (notificationPref != 0) {
-                context.stopService(serviceIntent);
-                context.startService(serviceIntent);
+                serviceIntent.putExtra("show_notification", isPlaying);
             } else
-                context.stopService(serviceIntent);
-        }
+                serviceIntent.putExtra("show_notification", false);
+
+            context.startService(serviceIntent);
+//        }
     }
 }

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -19,21 +19,16 @@
 
 package com.geecko.QuickLyric.broadcastReceiver;
 
-import android.app.Notification;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
 
 import com.geecko.QuickLyric.App;
-import com.geecko.QuickLyric.R;
 import com.geecko.QuickLyric.fragment.LyricsViewFragment;
+import com.geecko.QuickLyric.service.NotificationService;
 
 public class MusicBroadcastReceiver extends BroadcastReceiver {
 
@@ -106,31 +101,14 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
                 forceAutoUpdate(false);
             }
 
+            Intent serviceIntent = new Intent(context, NotificationService.class);
+            serviceIntent.putExtra("artist", artist);
+            serviceIntent.putExtra("track", track);
             if (notificationPref != 0) {
-                Intent activityIntent = new Intent("com.geecko.QuickLyric.getLyrics")
-                        .putExtra("TAGS", new String[]{artist, track});
-                PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, activityIntent,
-                        PendingIntent.FLAG_CANCEL_CURRENT);
-                NotificationCompat.Builder notifBuilder = new NotificationCompat.Builder(context);
-
-                if (sharedPref.getString("pref_theme", "0").equals("0"))
-                    notifBuilder.setColor(context.getResources().getColor(R.color.primary));
-                notifBuilder.setSmallIcon(R.drawable.ic_notif);
-                notifBuilder.setContentTitle(context.getString(R.string.app_name));
-                notifBuilder.setContentText(String.format("%s - %s", artist, track));
-                notifBuilder.setContentIntent(pendingIntent);
-                if (sharedPref.getBoolean("pref_hide_notification", false) && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN))
-                    notifBuilder.setPriority(Notification.PRIORITY_MIN);
-                else
-                    notifBuilder.setPriority(-1);
-                Notification notif = notifBuilder.build();
-                if (notificationPref == 2)
-                    notif.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;
-                else
-                    notif.flags |= Notification.FLAG_AUTO_CANCEL;
-                ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE))
-                        .notify(0, notif);
-            }
+                context.stopService(serviceIntent);
+                context.startService(serviceIntent);
+            } else
+                context.stopService(serviceIntent);
         }
     }
 }

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
@@ -181,16 +181,19 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
                 SharedPreferences current = getActivity().getSharedPreferences("current_music", Context.MODE_PRIVATE);
                 String artist = current.getString("artist", "Michael Jackson");
                 String track = current.getString("track", "Bad");
+                boolean isPlaying = current.getBoolean("playing", false);
                 int notificationPref = Integer.valueOf(sharedPreferences.getString("pref_notifications", "0"));
 
                 Intent serviceIntent = new Intent(getActivity(), NotificationService.class);
                 serviceIntent.putExtra("artist", artist);
                 serviceIntent.putExtra("track", track);
+                serviceIntent.putExtra("playing", isPlaying);
                 if (notificationPref != 0) {
-                    getActivity().stopService(serviceIntent);
-                    getActivity().startService(serviceIntent);
+                    serviceIntent.putExtra("show_notification", isPlaying);
                 } else
-                    getActivity().stopService(serviceIntent);
+                    serviceIntent.putExtra("show_notification", false);
+
+                getActivity().startService(serviceIntent);
 
                 break;
         }

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
@@ -66,8 +67,15 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
         };
         findPreference("pref_theme").setOnPreferenceChangeListener(prefChangeListener);
 
+        // Disable "Hide notification icon" preference on ICS
         if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN)
             findPreference("pref_hide_notification").setEnabled(false);
+
+        // Bind the summaries of EditText/List/Dialog/Ringtone preferences to
+        // their values. When their values change, their summaries are updated
+        // to reflect the new value, per the Android Design guidelines.
+
+        bindPreferenceSummaryToValue(findPreference("pref_theme"));
     }
 
 
@@ -197,5 +205,53 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
 
                 break;
         }
+    }
+
+    /**
+     * A preference value change listener that updates the preference's summary
+     * to reflect its new value.
+     */
+    private static Preference.OnPreferenceChangeListener sBindPreferenceSummaryToValueListener = new Preference.OnPreferenceChangeListener() {
+        @Override
+        public boolean onPreferenceChange(Preference preference, Object value) {
+            String stringValue = value.toString();
+
+            if(preference instanceof ListPreference) {
+                // For list preferences, look up the correct display value in
+                // the preference's 'entries' list.
+                ListPreference listPreference = (ListPreference) preference;
+                int index = listPreference.findIndexOfValue(stringValue);
+
+                // Set the summary to reflect the new value.
+                preference.setSummary(index >= 0 ? listPreference.getEntries()[index] : null);
+
+            } else {
+                // For all other preferences, set the summary to the value's
+                // simple string representation.
+                preference.setSummary(stringValue);
+            }
+
+            return true;
+        }
+    };
+
+    /**
+     * Binds a preference's summary to its value. More specifically, when the
+     * preference's value is changed, its summary (line of text below the
+     * preference title) is updated to reflect the value. The summary is also
+     * immediately updated upon calling this method. The exact display format is
+     * dependent on the type of preference.
+     *
+     * @see #sBindPreferenceSummaryToValueListener
+     */
+    private static void bindPreferenceSummaryToValue(Preference preference) {
+        // Set the listener to watch for value changes.
+        preference.setOnPreferenceChangeListener(sBindPreferenceSummaryToValueListener);
+
+        // Trigger the listener immediately with the preference's
+        // current value.
+        sBindPreferenceSummaryToValueListener.onPreferenceChange
+                (preference, PreferenceManager.getDefaultSharedPreferences(preference.getContext()).getString(preference.getKey(), ""));
+
     }
 }

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
@@ -23,6 +23,7 @@ import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
@@ -60,6 +61,9 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
             }
         };
         findPreference("pref_theme").setOnPreferenceChangeListener(prefChangeListener);
+
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN)
+            findPreference("pref_hide_notification").setEnabled(false);
     }
 
     @Override

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/service/NotificationService.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/service/NotificationService.java
@@ -1,0 +1,80 @@
+/*
+ * *
+ *  * This file is part of QuickLyric
+ *  * Created by geecko
+ *  *
+ *  * QuickLyric is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * QuickLyric is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with QuickLyric.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.geecko.QuickLyric.service;
+
+import android.annotation.TargetApi;
+import android.app.IntentService;
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
+
+import com.geecko.QuickLyric.R;
+
+public class NotificationService extends IntentService {
+
+    /**
+     * A constructor is required, and must call the super IntentService(String)
+     * constructor with a name for the worker thread.
+     */
+    public NotificationService() {
+        super("NotificationService");
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        // Load preferences
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
+        SharedPreferences current = getSharedPreferences("current_music", Context.MODE_PRIVATE);
+        int notificationPref = Integer.valueOf(sharedPref.getString("pref_notifications", "0"));
+        String artist = current.getString("artist", "Michael Jackson");
+        String track = current.getString("track", "Bad");
+
+        Intent activityIntent = new Intent("com.geecko.QuickLyric.getLyrics")
+                .putExtra("TAGS", new String[]{artist, track});
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, activityIntent,
+                PendingIntent.FLAG_CANCEL_CURRENT);
+        NotificationCompat.Builder notifBuilder = new NotificationCompat.Builder(this);
+
+        if (sharedPref.getString("pref_theme", "0").equals("0"))
+            notifBuilder.setColor(getResources().getColor(R.color.primary));
+        notifBuilder.setSmallIcon(R.drawable.ic_notif);
+        notifBuilder.setContentTitle(getString(R.string.app_name));
+        notifBuilder.setContentText(String.format("%s - %s", artist, track));
+        notifBuilder.setContentIntent(pendingIntent);
+        if (sharedPref.getBoolean("pref_hide_notification", false) && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN))
+            notifBuilder.setPriority(Notification.PRIORITY_MIN);
+        else
+            notifBuilder.setPriority(-1);
+        Notification notif = notifBuilder.build();
+        if (notificationPref == 2)
+            notif.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;
+        else
+            notif.flags |= Notification.FLAG_AUTO_CANCEL;
+        ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
+                .notify(0, notif);
+	}
+}

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/service/NotificationService.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/service/NotificationService.java
@@ -74,7 +74,14 @@ public class NotificationService extends IntentService {
             notif.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;
         else
             notif.flags |= Notification.FLAG_AUTO_CANCEL;
-        ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
-                .notify(0, notif);
+
+        if (intent.getBooleanExtra("show_notification", true))
+            ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
+                    .notify(0, notif);
+        else
+            ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
+                    .cancel(0);
+
+
 	}
 }

--- a/QuickLyric/src/main/res/values-es/strings.xml
+++ b/QuickLyric/src/main/res/values-es/strings.xml
@@ -67,6 +67,7 @@
   <string name="defaut_theme">Ámbar (Por defecto)</string>
   <string name="dark_theme">Oscuro</string>
   <string name="pref_notifications_sum">Tenga notificaciones discretas cuando la canción cambia</string>
+  <string name="pref_hide_notification">Ocultar notificaciones</string>
   <string-array name="sort_modes">
     <item>Por artista&#8230;</item>
     <item>Por titulo&#8230;</item>

--- a/QuickLyric/src/main/res/values-fr/strings.xml
+++ b/QuickLyric/src/main/res/values-fr/strings.xml
@@ -67,6 +67,7 @@
   <string name="defaut_theme">Ambre (par défaut)</string>
   <string name="dark_theme">Sombre</string>
   <string name="pref_notifications_sum">Recevez une notification discrète lorsque la chanson change</string>
+  <string name="pref_hide_notification">Masquer la notification</string>
   <string-array name="sort_modes">
     <item>Par Artiste&#8230;</item>
     <item>Par Titre&#8230;</item>

--- a/QuickLyric/src/main/res/values/strings.xml
+++ b/QuickLyric/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ /**
   ~  * This file is part of QuickLyric
@@ -162,6 +162,7 @@ Terms of service available at:
     <string name="defaut_theme">Amber (Default)</string>
     <string name="dark_theme">Dark</string>
     <string name="pref_notifications_sum">Get a discrete notification when the song changes</string>
+    <string name="pref_hide_notification">Hide notification icon</string>
 
     <string-array name="nav_items">
         <item>@string/title_lyrics</item>

--- a/QuickLyric/src/main/res/xml/preferences.xml
+++ b/QuickLyric/src/main/res/xml/preferences.xml
@@ -44,6 +44,10 @@
             android:entries="@array/notifications"
             android:entryValues="@array/notifications_values"
             android:defaultValue="0" />
+        <CheckBoxPreference
+            android:key="pref_hide_notification"
+            android:title="@string/pref_hide_notification"
+            android:defaultValue="false" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_more_category">


### PR DESCRIPTION
This set of commits offers several improvements for the new notification functionality:
* Notification now appears when a song is played and disappears when a song is paused.  (Only tested on Google Play Music; other media players will need support for the .playstatechanged intent added)
* Notification settings are now immediately applied when the disable/enable option is changed in Settings (fixes issue #31 )
* New setting for hiding the notification icon on Jelly Bean and up

In addition, this pull request includes a small change to the Themes setting to show the name of the currently active theme as the summary.