### PR TITLE
Notification improvements, round 2

### DIFF
--- a/QuickLyric/src/main/AndroidManifest.xml
+++ b/QuickLyric/src/main/AndroidManifest.xml
@@ -111,6 +111,7 @@
             android:name=".broadcastReceiver.MusicBroadcastReceiver"
             tools:ignore="ExportedReceiver">
             <intent-filter>
+                <action android:name="com.geecko.QuickLyric.SHOW_NOTIFICATION" />
                 <action android:name="com.jrtstudio.music.metachanged" />
                 <action android:name="com.jrtstudio.music.playstatechanged" />
                 <action android:name="com.jrtstudio.AnotherMusicPlayer.metachanged" />

--- a/QuickLyric/src/main/AndroidManifest.xml
+++ b/QuickLyric/src/main/AndroidManifest.xml
@@ -112,8 +112,11 @@
             tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.jrtstudio.music.metachanged" />
+                <action android:name="com.jrtstudio.music.playstatechanged" />
                 <action android:name="com.jrtstudio.AnotherMusicPlayer.metachanged" />
+                <action android:name="com.jrtstudio.AnotherMusicPlayer.playstatechanged" />
                 <action android:name="com.android.music.metachanged" />
+                <action android:name="com.android.music.playstatechanged" />
                 <action android:name="com.htc.music.metachanged" />
                 <action android:name="com.rdio.android.playstatechanged" />
                 <action android:name="fm.last.android.metachanged" />

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -85,17 +85,11 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
             return;
 
         SharedPreferences current = context.getSharedPreferences("current_music", Context.MODE_PRIVATE);
-
-        String currentArtist = current.getString("artist", "Michael Jackson");
-        String currentTrack = current.getString("track", "Bad");
-
-        if (!currentArtist.equals(artist) || !currentTrack.equals(track)) {
-
-            SharedPreferences.Editor editor = current.edit();
-            editor.putString("artist", artist);
-            editor.putString("track", track);
-            editor.apply();
-        }
+        SharedPreferences.Editor editor = current.edit();
+        editor.putString("artist", artist);
+        editor.putString("track", track);
+        editor.putBoolean("playing", isPlaying);
+        editor.apply();
 
         mAutoUpdate = mAutoUpdate || sharedPref.getBoolean("pref_auto_refresh", false);
         int notificationPref = Integer.valueOf(sharedPref.getString("pref_notifications", "0"));

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -72,7 +72,7 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
 
         String artist = extras.getString("artist");
         String track = extras.getString("track");
-        boolean isPlaying = extras.getBoolean("playing");
+        boolean isPlaying = extras.getBoolean("playing", true);
 
         if (intent.getAction().equals("com.amazon.mp3.metachanged")) {
             artist = extras.getString("com.amazon.mp3.artist");

--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/fragment/SettingsFragment.java
@@ -25,6 +25,7 @@ import android.app.AlertDialog;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
@@ -68,8 +69,18 @@ public class SettingsFragment extends PreferenceFragment implements
                 }
                 return true;
             case "pref_notifications":
-                ((NotificationManager) getActivity()
-                        .getSystemService(Context.NOTIFICATION_SERVICE)).cancelAll();
+                if (newValue.equals("0")) {
+                    ((NotificationManager) getActivity()
+                            .getSystemService(Context.NOTIFICATION_SERVICE)).cancelAll();
+                } else {
+                    SharedPreferences current = getActivity().getSharedPreferences("current_music", Context.MODE_PRIVATE);
+                    Intent intent = new Intent();
+                    intent.setAction("com.geecko.QuickLyric.SHOW_NOTIFICATION");
+                    intent.putExtra("artist", current.getString("artist", "Michael Jackson"));
+                    intent.putExtra("track", current.getString("track", "Bad"));
+                    intent.putExtra("playing", current.getBoolean("playing", false));
+                    getActivity().sendBroadcast(intent);
+                }
                 return true;
         }
         return false;


### PR DESCRIPTION
This improves QuickLyric's notification functionality by implementing the following:
* Notification appears when a song is played and disappears when a song is paused.  (Tested and working with: AOSP music app, Google Play Music, RocketPlayer, Apollo, GoneMAD, Poweramp.)  For applications that don't broadcast their playback state, the old notification behavior will still apply.
* Notification settings are now immediately applied when the disable/enable option is changed in Settings.  In the current version, the notification always disappears whenever that setting is changed (most likely a bug). 