### PR TITLE
Fix "Ignore long tracks" preference

### DIFF
--- a/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
+++ b/QuickLyric/src/main/java/com/geecko/QuickLyric/broadcastReceiver/MusicBroadcastReceiver.java
@@ -64,7 +64,7 @@ public class MusicBroadcastReceiver extends BroadcastReceiver {
 
         Bundle extras = intent.getExtras();
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean lengthFilter = sharedPref.getBoolean("filter_20min", true);
+        boolean lengthFilter = sharedPref.getBoolean("pref_filter_20min", true);
 
         if (extras != null)
             try {


### PR DESCRIPTION
The "Ignore long tracks" preference was not correctly working due to a
typo in MusicBroadcastReceiver.  This corrects the preference value,
allowing it to work.